### PR TITLE
Implement queue system

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,8 @@ Let hubot keep track of which developer is using which sandbox. Works for develo
 * hubot I'm using sandbox [name] - Assign a sandbox to yourself
 * hubot release sandbox [name] - Free a sandbox for use by someone else
 * hubot add sandbox [name] - Add a new sandbox
-* hubot delete|remote sandbox [name] - Delete a sandbox
+* hubot delete|remove sandbox [name] - Delete a sandbox
+* hubot show queue - show all of the suckers waiting for the next sandbox
+* hubot queue sandbox - add yourself to the queue for the next released sandbox
+* hubot dequeue|unqueue sandbox - remove youself from the queue
+* hubot remove [username] from queue - remove some jerk from the queue

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hubot-sandboxes",
   "version": "0.0.1",
   "description": "Keep track of which developer is using which sandbox",
-  "main": "./sandboxes.coffee",
+  "main": "sandboxes.coffee",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-sandboxes",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Keep track of which developer is using which sandbox",
   "main": "sandboxes.coffee",
   "scripts": {

--- a/sandboxes.coffee
+++ b/sandboxes.coffee
@@ -9,7 +9,7 @@
 #
 # Commands:
 #   hubot list|show sandboxes - List the sandboxes and their availability
-#   hubot assign sandbox <name> to @<user> - Assign a sandbox to a user
+#   hubot assign sandbox <name> to <user> - Assign a sandbox to a user
 #   hubot I'm using sandbox <name> - Assign a sandbox to yourself
 #   hubot release sandbox <name> - Free a sandbox for use by someone else
 #   hubot add sandbox <name> - Add a new sandbox
@@ -17,7 +17,7 @@
 #   hubot show queue - show all of the suckers waiting for the next sandbox
 #   hubot queue sandbox - add yourself to the queue for the next released sandbox
 #   hubot dequeue|unqueue sandbox - remove youself from the queue
-#   hubot remove [username] from queue - remove some jerk from the queue
+#   hubot remove <user> from queue - remove some jerk from the queue
 #
 # Notes:
 #   sandbox names are stored lowercased
@@ -51,7 +51,7 @@ module.exports = (robot) ->
     msg.send "Sandboxes:\n" + human_text.join("\n")
 
 
-  robot.respond /assign s(?:andbox)? ([A-Za-x0-9-_]+) to @?([A-Za-x0-9-_]+)/i, (msg) ->
+  robot.respond /assign s(?:andbox)? ([A-Za-x0-9-_]+) to ([A-Za-x0-9-_ ]+)/i, (msg) ->
     user_id = robot.brain.userForName(msg.match[2])?.id
     return msg.reply "I have no idea who you're talking about" unless user_id
 
@@ -83,7 +83,7 @@ module.exports = (robot) ->
   robot.respond /(de|un)queue s(?:andbox)/i, (msg) ->
     dequeue msg.message.user.id, msg
 
-  robot.respond /remove @?([A-Za-x0-9-_]+) from q(?:ueue)?/i, (msg) ->
+  robot.respond /remove ([A-Za-x0-9-_ ]+) from q(?:ueue)?/i, (msg) ->
     user_id = robot.brain.userForName(msg.match[1])?.id
     dequeue user_id, msg
 

--- a/sandboxes.coffee
+++ b/sandboxes.coffee
@@ -26,7 +26,7 @@ moment = require 'moment'
 module.exports = (robot) ->
   robot.brain.on 'loaded', =>
     robot.brain.data.sandboxes ||= {}
-    robot.brain.data.sandboxQueue ||= new SimpleQueue
+    robot.brain.data.sandboxQueue = new SimpleQueue(robot.brain.data.sandboxQueue || [])
 
 
   robot.respond /(list|show) sandboxes/i, (msg) ->
@@ -68,15 +68,15 @@ module.exports = (robot) ->
     queue = robot.brain.data.sandboxQueue
     waiting = queue.dequeue()
     if waiting
-      username = robot.brain.userForId(waiting)
+      username = robot.brain.userForId(waiting).name
       msg.reply "Auto-assigning sandbox to @" + username
       assignSandbox waiting, sandbox_name, msg
 
 
-  robot.respond /queue sandbox/i, (msg) ->
+  robot.respond /queue s(?:andbox)/i, (msg) ->
     queue msg.message.user.id, msg
 
-  robot.respond /(de|un)queue sandbox/i, (msg) ->
+  robot.respond /(de|un)queue s(?:andbox)/i, (msg) ->
     dequeue msg.message.user.id, msg
 
   robot.respond /remove @?([A-Za-x0-9-_]+) from q(?:ueue)?/i, (msg) ->
@@ -118,6 +118,7 @@ module.exports = (robot) ->
 
   robot.respond /disassemble sandboxes/i, (msg) ->
     robot.brain.data.sandboxes = {}
+    robot.brain.data.sandboxQueue = {}
     clearQueue()
     msg.send "Bye bye Johnny 5"
 
@@ -172,8 +173,8 @@ class Sandbox
 
 # a very simple queue that doesn't allow duplicates and can be iterated
 class SimpleQueue
-  constructor: () ->
-    @_queue = []
+  constructor: (options) ->
+    @_queue = options._queue || []
 
   enqueue: (item) ->
     if @isQueued item
@@ -197,4 +198,3 @@ class SimpleQueue
 
   items: () ->
     return @_queue
-  

--- a/sandboxes.coffee
+++ b/sandboxes.coffee
@@ -14,6 +14,10 @@
 #   hubot release sandbox <name> - Free a sandbox for use by someone else
 #   hubot add sandbox <name> - Add a new sandbox
 #   hubot delete|remote sandbox <name> - Delete a sandbox
+#   hubot show queue - show all of the suckers waiting for the next sandbox
+#   hubot queue sandbox - add yourself to the queue for the next released sandbox
+#   hubot dequeue|unqueue sandbox - remove youself from the queue
+#   hubot remove [username] from queue - remove some jerk from the queue
 #
 # Notes:
 #   sandbox names are stored lowercased

--- a/sandboxes.coffee
+++ b/sandboxes.coffee
@@ -24,9 +24,9 @@
 moment = require 'moment'
 
 module.exports = (robot) ->
-
   robot.brain.on 'loaded', =>
     robot.brain.data.sandboxes ||= {}
+    robot.brain.data.sandboxQueue ||= new SimpleQueue
 
 
   robot.respond /(list|show) sandboxes/i, (msg) ->
@@ -64,6 +64,41 @@ module.exports = (robot) ->
     sandbox_name = msg.match[1].toString()
     assignSandbox null, sandbox_name, msg
 
+    # now try and auto-assign the top person in the queue
+    queue = robot.brain.data.sandboxQueue
+    waiting = queue.dequeue()
+    if waiting
+      username = robot.brain.userForId(waiting)
+      msg.reply "Auto-assigning sandbox to @" + username
+      assignSandbox waiting, sandbox_name, msg
+
+
+  robot.respond /queue sandbox/i, (msg) ->
+    queue msg.message.user.id, msg
+
+  robot.respond /(de|un)queue sandbox/i, (msg) ->
+    dequeue msg.message.user.id, msg
+
+  robot.respond /remove @?([A-Za-x0-9-_]+) from q(?:ueue)?/i, (msg) ->
+    user_id = robot.brain.userForName(msg.match[1])?.id
+    dequeue user_id, msg
+
+
+  robot.respond /show queue/i, (msg) ->
+    queue = robot.brain.data.sandboxQueue
+    unless queue.peek()
+      return msg.send "No one is in the queue"
+
+    human_text = ((i + 1) + ": " + robot.brain.userForId(userId).name for userId, i in queue.items())
+
+    msg.send "Queue:\n" + human_text.join("\n")
+
+
+  robot.respond /clear queue/i, (msg) ->
+    clearQueue()
+
+    msg.send "Queue cleared"
+
 
   robot.respond /add s(?:andbox)? ([A-za-z0-9-_]+)/i, (msg) ->
     sandbox_name = msg.match[1].toString().toLowerCase()
@@ -83,6 +118,7 @@ module.exports = (robot) ->
 
   robot.respond /disassemble sandboxes/i, (msg) ->
     robot.brain.data.sandboxes = {}
+    clearQueue()
     msg.send "Bye bye Johnny 5"
 
 
@@ -105,6 +141,23 @@ module.exports = (robot) ->
     msg.reply "Got it"
 
 
+  queue = (user_id, msg) ->
+    unless robot.brain.data.sandboxQueue.enqueue(user_id)
+      return msg.reply "You're already in the queue"
+
+    msg.reply "I added you to the queue"
+
+
+  dequeue = (user_id, msg) ->
+    unless robot.brain.data.sandboxQueue.dequeue(user_id)
+      return msg.reply "You're not in the queue"
+
+    msg.reply "Got it"
+
+  clearQueue = () ->
+    robot.brain.data.sandboxQueue = new SimpleQueue
+
+
 class Sandbox
   constructor: (options) ->
     @owner = options.owner
@@ -116,3 +169,32 @@ class Sandbox
   ownerName: (brain) ->
     return "Nobody" unless @owner
     return brain.userForId(@owner).name
+
+# a very simple queue that doesn't allow duplicates and can be iterated
+class SimpleQueue
+  constructor: () ->
+    @_queue = []
+
+  enqueue: (item) ->
+    if @isQueued item
+      return false
+
+    @_queue.push(item)
+
+    return item
+
+  dequeue: (item) ->
+    unless (not item or @isQueued item) and @_queue.length isnt 0
+      return false
+
+    return @_queue.shift()
+
+  isQueued: (item) ->
+    return item in @_queue
+
+  peek: () ->
+    return @_queue[0]
+
+  items: () ->
+    return @_queue
+  

--- a/sandboxes.coffee
+++ b/sandboxes.coffee
@@ -77,10 +77,10 @@ module.exports = (robot) ->
       assignSandbox waiting, sandbox_name, msg
 
 
-  robot.respond /queue s(?:andbox)/i, (msg) ->
+  robot.respond /queue s(?:andbox)?/i, (msg) ->
     queue msg.message.user.id, msg
 
-  robot.respond /(de|un)queue s(?:andbox)/i, (msg) ->
+  robot.respond /(de|un)queue s(?:andbox)?/i, (msg) ->
     dequeue msg.message.user.id, msg
 
   robot.respond /remove ([A-Za-x0-9-_ ]+) from q(?:ueue)?/i, (msg) ->


### PR DESCRIPTION
This is a first attempt to implement a queue system.  The following
commands are implemented:
- hubot queue sandbox - adds /me to the queue
- hubot (de|un)queue sandbox - removes /me from the queue
- hubot remove [user] from queue - forcibly removes [user] from the
  queue
- hubot clear queue - clears the queue
- hubot show queue - shows a list (in priority order) of who's in the
  queue

When a user releases a sandbox, then the next person in the queue will
be auto-assigned that sandbox and the person will be removed from the
queue.

I am new to coffeescript, so it is likely I have done something dumb.  I
also can't get the queue to initialize/save properly , at least in my
test environment.  I always have to do "hubot clear queue" first to be
able to do anything with it.  I don't know if it is just the environment
or if it is a problem with the script.
